### PR TITLE
Updated path for CWA Windows JA 106 KeyboardType

### DIFF
--- a/kbime-config/keyboard-and-ime-configuration.md
+++ b/kbime-config/keyboard-and-ime-configuration.md
@@ -449,7 +449,7 @@ The following table shows how to configure Japanese 106 keyboard.
 
 | <center>Citrix Workspace app</center> | <center>Japanese 106  Keyboard Support</center>              |
 | ------------------------------------- | ------------------------------------------------------------ |
-| Citrix Workspace app for Windows      | Support to **detect client keyboard type automatically when session  starts.** Or manually configure:  File path:  “%appdata%\ICAClient\WFCLIENT.ini”  Change setting in [WFClient]: KeyboardType=106 Keyboard  (Japanese) |
+| Citrix Workspace app for Windows      | Support to **detect client keyboard type automatically when session  starts.** Or manually configure:  File path:  “%appdata%\ICAClient\APPSRV.INI”  Change setting in [WFClient]: KeyboardType=106 Keyboard  (Japanese) |
 | Citrix Workspace app for MAC          | File path: `~/Library/Application Support/Citrix  Receiver/Config`. Change setting in `[WFClient]`: `KeyboardType=106 Keyboard  (Japanese)` |
 | Citrix Workspace app for Linux        | File path:  `~/.ICAClient/wfclient.ini`. Change setting in `[WFClient]`: `KeyboardType=106 Keyboard  (Japanese)` |
 | Citrix Workspace app for Android      | Not supported                                                |


### PR DESCRIPTION
Updated the correct path for CWA Windows KeyboardType=106 Keyboard (Japanese)
https://github.com/klu-dev/citrix-keyboard-ime-docs/blob/main/kbime-config/keyboard-and-ime-configuration.md#:~:text=106%20Keyboard%20Support-,Citrix%20Workspace%20app%20for%20Windows,WFCLIENT.ini%E2%80%9D%20Change%20setting%20in%20%5BWFClient%5D%3A%20KeyboardType%3D106%20Keyboard%20(Japanese),-Citrix%20Workspace%20app